### PR TITLE
Let h_pos and v_pos go under 0

### DIFF
--- a/yx-touch-controls/objects/obj_touchAnalog/Step_0.gml
+++ b/yx-touch-controls/objects/obj_touchAnalog/Step_0.gml
@@ -142,33 +142,25 @@ if ( dist > 0 ) {
     if ( thumb_x > x ) {
         x_pos   = thumb_x - x - dead_min;
     } else if ( thumb_x < x ) {
-        x_pos   = x - thumb_x - dead_min;
+        x_pos   = 0 - ( x - thumb_x - dead_min );
     } else {
         x_pos   = 0;
     }
     
     // Check H pos
-    if ( x_pos > 0 ) {
-        h_pos   = x_pos / ( thumb_max * deadzone_r );
-    } else {
-        h_pos   = 0;
-    }
+    h_pos   = x_pos / ( thumb_max * deadzone_r );
     
     // Check thumb Y
     if ( thumb_y > y ) {
         y_pos   = thumb_y - y - dead_min;
     } else if ( thumb_y < y ) {
-        y_pos   = y - thumb_y - dead_min;
+        y_pos   = 0 - ( y - thumb_y - dead_min );
     } else {
         y_pos   = 0;
     }
     
     // Check V pos
-    if ( y_pos > 0 ) {
-        v_pos   = y_pos / ( thumb_max * deadzone_r );
-    } else {
-        v_pos   = 0;
-    }
+    v_pos   = y_pos / ( thumb_max * deadzone_r );
 }
 
 // Checks hold and press states and, if both are false, return to center


### PR DESCRIPTION
(Note: this PR only fixes the GMS2 project, as I don't have GMS1 installed to edit the files)

Currently, `h_pos` and `v_pos` are always positive, so the stated range of -1 to 1 is false.
If the x or y positions of the joystick are negative, they end up positive (due to subtracting negatives from negatives). Even if the coords are positive, there's a check in there for some reason to return 0 if the values are negative. This PR fixes the negative issue and removes the check, allowing `h_pos` and `v_pos` to work properly whether the coords are negative or positive (with the stated range of -1 to 1).